### PR TITLE
fix: optimize initial load of page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,27 +25,27 @@
     <nav id="navbar">
       <div class="container">
         <ul class="navbar-list">
-          <li class="navbar-item navbar-item-mascot">
+          <li class="navbar-item navbar-item-mascot hide-mobile">
             <img class="navbar-logo" src="./img/mascot/wizard.png" alt="wizard">
             <a class="navbar-link" href="#products">Experience the magic</a>
             <div class="firework"></div>
           </li>
-          <li class="navbar-item navbar-item-home">
+          <li class="navbar-item navbar-item-home hide-mobile">
             <a class="navbar-link" href="#header">Home</a>
           </li>
-          <li class="navbar-item">
+          <li class="navbar-item hide-mobile">
             <a class="navbar-link" href="#products">Products</a>
           </li>
-          <li class="navbar-item">
+          <li class="navbar-item hide-mobile">
             <a class="navbar-link" href="#reviews">Reviews</a>
           </li>
-          <li class="navbar-item">
+          <li class="navbar-item hide-mobile">
             <a class="navbar-link" href="#about-us">About us</a>
           </li>
-          <li class="navbar-item">
+          <li class="navbar-item hide-mobile">
             <a class="navbar-link" href="#contact">Contact</a>
           </li>
-          <li class="navbar-item">
+          <li class="navbar-item hide-mobile">
             <button id="cartBtn" class="navbar-link navbar-link-icon" href="#">
               <img
                 class="navbar-icon"
@@ -55,13 +55,13 @@
               <span id="productCounter">0</span>
             </button>
           </li>
-          <div class="navbar-item navbar-item-mobile">
+          <li class="navbar-item navbar-item-mobile">
             <button id="toggleMenu">
               <div class="menu-line"></div>
               <div class="menu-line"></div>
               <div class="menu-line"></div>
             </button>
-          </div>
+          </li>
         </ul>
       </div>
     </nav>

--- a/js/main.js
+++ b/js/main.js
@@ -63,15 +63,6 @@ function hideElements() {
     for (let i = 3; i < products.length; i++) {
       products[i].classList.add('hide-mobile');
     }
-    
-    // Hide navbar items on mobile initially
-    navbarItems.forEach((item) => {
-      if (!toggleBtn.classList.contains('active') 
-       && !item.classList.contains('navbar-item-mobile')) {
-        item.classList.add('hide-mobile');
-      }
-    });
-
   } else {
     for (let i = 3; i < products.length; i++) {
       products[i].classList.remove('hide-mobile');


### PR DESCRIPTION
Remove the part that would add the `hide-mobile` classes to items, as it was too slow and visible to eye on initial load/refresh.